### PR TITLE
get_spreadsheetへのアクセスをインスタンスごと1回だけするように変更

### DIFF
--- a/lib/google_spreadsheet_fetcher/fetcher.rb
+++ b/lib/google_spreadsheet_fetcher/fetcher.rb
@@ -88,7 +88,7 @@ module GoogleSpreadsheetFetcher
     end
 
     def spreadsheet
-      service.get_spreadsheet(@spreadsheet_id)
+      @spreadsheet ||= service.get_spreadsheet(@spreadsheet_id)
     end
 
     def fill_array(items, count, fill: "")


### PR DESCRIPTION
一つのスプレッドシートに対して `fetch_all_rows` を複数回回すようなケースの場合に、シートごとに `get_spreadsheet` を叩く無駄なAPIアクセスが発生していたため、1度 `get_spreadsheet` した結果を使い回すように修正しました。