### PR TITLE
SheetsServiceBuilder初期化時に、NoMethodError: undefined method `token_store' for nil:NilClass になるのを修正しました

### DIFF
--- a/lib/google_spreadsheet_fetcher/sheets_service_builder.rb
+++ b/lib/google_spreadsheet_fetcher/sheets_service_builder.rb
@@ -14,7 +14,7 @@ module GoogleSpreadsheetFetcher
       @user_id = user_id
       @config = config || GoogleSpreadsheetFetcher.config
       @application_name = application_name
-      @token_store = config.token_store || Google::Auth::Stores::FileTokenStore.new(file: @config.credential_store_file)
+      @token_store = @config.token_store || Google::Auth::Stores::FileTokenStore.new(file: @config.credential_store_file)
     end
 
     def build


### PR DESCRIPTION
### やったこと
- config未指定の状態でSheetsServiceBuilderを初期化した際にNoMethodError: undefined method `token_store' for nil:NilClassになるのを修正しました